### PR TITLE
Fix Text Domain Issue (Based on the newest code 2.0.2)

### DIFF
--- a/classes/class-rpwe-widget.php
+++ b/classes/class-rpwe-widget.php
@@ -334,8 +334,8 @@ class RPWE_Widget extends WP_Widget {
 								<?php esc_attr_e( 'Order', 'recent-posts-widget-extended' ); ?>
 							</label>
 							<select class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'order' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'order' ) ); ?>" style="width:100%;">
-								<option value="DESC" <?php selected( $instance['order'], 'DESC' ); ?>><?php esc_attr_e( 'Descending', 'rpwe' ); ?></option>
-								<option value="ASC" <?php selected( $instance['order'], 'ASC' ); ?>><?php esc_attr_e( 'Ascending', 'rpwe' ); ?></option>
+								<option value="DESC" <?php selected( $instance['order'], 'DESC' ); ?>><?php esc_attr_e( 'Descending', 'recent-posts-widget-extended' ); ?></option>
+								<option value="ASC" <?php selected( $instance['order'], 'ASC' ); ?>><?php esc_attr_e( 'Ascending', 'recent-posts-widget-extended' ); ?></option>
 							</select>
 						</p>
 
@@ -344,14 +344,14 @@ class RPWE_Widget extends WP_Widget {
 								<?php esc_attr_e( 'Orderby', 'recent-posts-widget-extended' ); ?>
 							</label>
 							<select class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'orderby' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'orderby' ) ); ?>" style="width:100%;">
-								<option value="ID" <?php selected( $instance['orderby'], 'ID' ); ?>><?php esc_attr_e( 'ID', 'rpwe' ); ?></option>
-								<option value="author" <?php selected( $instance['orderby'], 'author' ); ?>><?php esc_attr_e( 'Author', 'rpwe' ); ?></option>
-								<option value="title" <?php selected( $instance['orderby'], 'title' ); ?>><?php esc_attr_e( 'Title', 'rpwe' ); ?></option>
-								<option value="date" <?php selected( $instance['orderby'], 'date' ); ?>><?php esc_attr_e( 'Date', 'rpwe' ); ?></option>
-								<option value="modified" <?php selected( $instance['orderby'], 'modified' ); ?>><?php esc_attr_e( 'Modified', 'rpwe' ); ?></option>
-								<option value="rand" <?php selected( $instance['orderby'], 'rand' ); ?>><?php esc_attr_e( 'Random', 'rpwe' ); ?></option>
-								<option value="comment_count" <?php selected( $instance['orderby'], 'comment_count' ); ?>><?php esc_attr_e( 'Comment Count', 'rpwe' ); ?></option>
-								<option value="menu_order" <?php selected( $instance['orderby'], 'menu_order' ); ?>><?php esc_attr_e( 'Menu Order', 'rpwe' ); ?></option>
+								<option value="ID" <?php selected( $instance['orderby'], 'ID' ); ?>><?php esc_attr_e( 'ID', 'recent-posts-widget-extended' ); ?></option>
+								<option value="author" <?php selected( $instance['orderby'], 'author' ); ?>><?php esc_attr_e( 'Author', 'recent-posts-widget-extended' ); ?></option>
+								<option value="title" <?php selected( $instance['orderby'], 'title' ); ?>><?php esc_attr_e( 'Title', 'recent-posts-widget-extended' ); ?></option>
+								<option value="date" <?php selected( $instance['orderby'], 'date' ); ?>><?php esc_attr_e( 'Date', 'recent-posts-widget-extended' ); ?></option>
+								<option value="modified" <?php selected( $instance['orderby'], 'modified' ); ?>><?php esc_attr_e( 'Modified', 'recent-posts-widget-extended' ); ?></option>
+								<option value="rand" <?php selected( $instance['orderby'], 'rand' ); ?>><?php esc_attr_e( 'Random', 'recent-posts-widget-extended' ); ?></option>
+								<option value="comment_count" <?php selected( $instance['orderby'], 'comment_count' ); ?>><?php esc_attr_e( 'Comment Count', 'recent-posts-widget-extended' ); ?></option>
+								<option value="menu_order" <?php selected( $instance['orderby'], 'menu_order' ); ?>><?php esc_attr_e( 'Menu Order', 'recent-posts-widget-extended' ); ?></option>
 							</select>
 						</p>
 
@@ -390,9 +390,9 @@ class RPWE_Widget extends WP_Widget {
 							</label>
 							<input type="text" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'taxonomy' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'taxonomy' ) ); ?>" value="<?php echo esc_attr( $instance['taxonomy'] ); ?>" />
 							<small>
-								<?php esc_attr_e( 'Ex: category=1,2,4&amp;post_tag=6,12. ', 'rpwe' ); ?>
+								<?php esc_attr_e( 'Ex: category=1,2,4&amp;post_tag=6,12. ', 'recent-posts-widget-extended' ); ?>
 								<?php
-								esc_attr_e( 'Available: ', 'rpwe' );
+								esc_attr_e( 'Available: ', 'recent-posts-widget-extended' );
 								echo implode( ', ', get_taxonomies( array( 'public' => true ) ) );
 								?>
 							</small>

--- a/includes/defaults.php
+++ b/includes/defaults.php
@@ -13,7 +13,7 @@ function rpwe_get_default_args() {
 	$css_defaults = ".rpwe-block ul{\nlist-style: none !important;\nmargin-left: 0 !important;\npadding-left: 0 !important;\n}\n\n.rpwe-block li{\nborder-bottom: 1px solid #eee;\nmargin-bottom: 10px;\npadding-bottom: 10px;\nlist-style-type: none;\ndisplay: block;\n}\n\n.rpwe-block a{\ndisplay: inline !important;\ntext-decoration: none;\n}\n\n.rpwe-block h3{\nbackground: none !important;\nclear: none;\nmargin-bottom: 0 !important;\nmargin-top: 0 !important;\nfont-weight: 400;\nfont-size: 12px !important;\nline-height: 1.5em;\n}\n\n.rpwe-thumb{\nborder: 1px solid #eee !important;\nbox-shadow: none !important;\nmargin: 2px 10px 2px 0;\npadding: 3px !important;\n}\n\n.rpwe-summary{\nfont-size: 12px;\n}\n\n.rpwe-time{\ncolor: #bbb;\nfont-size: 11px;\n}\n\n.rpwe-comment{\ncolor: #bbb;\nfont-size: 11px;\npadding-left: 5px;\n}\n\n.rpwe-alignleft{\ndisplay: inline;\nfloat: left;\n}\n\n.rpwe-alignright{\ndisplay: inline;\nfloat: right;\n}\n\n.rpwe-aligncenter{\ndisplay: block;\nmargin-left: auto;\nmargin-right: auto;\n}\n\n.rpwe-clearfix:before,\n.rpwe-clearfix:after{\ncontent: \"\";\ndisplay: table !important;\n}\n\n.rpwe-clearfix:after{\nclear: both;\n}\n\n.rpwe-clearfix{\nzoom: 1;\n}\n";
 
 	$defaults = array(
-		'title'           => esc_attr__( 'Recent Posts', 'rpwe' ),
+		'title'           => esc_attr__( 'Recent Posts', 'recent-posts-widget-extended' ),
 		'title_url'       => '',
 
 		'limit'           => 5,


### PR DESCRIPTION
Change text domain from `rpwe` to `recent-posts-widget-extended` to display UI translations correctly.